### PR TITLE
Fix only number mask

### DIFF
--- a/masked-text-field-common.ts
+++ b/masked-text-field-common.ts
@@ -65,7 +65,7 @@ export abstract class MaskedTextFieldBase extends TextField implements MaskedTex
     }
 
     public _generateMaskTokens() {
-        const maskChars = this.mask.split("");
+        const maskChars = this.mask.toString().split("");
         const emptyMaskedValueBuider: string[] = [];
         let isEscapeCharIn = false;
 


### PR DESCRIPTION
#8 

Fix, if the mask is only numbers trigger the error described in the pull request.

Example:

mask="999" or mask="000".

In this case it doesn't work for zeros, because it transforms 000 into 0. But this is a temporarily fix that solves part of the problem.