### PR TITLE
fix angular imports

### DIFF
--- a/angular/index.ts
+++ b/angular/index.ts
@@ -1,6 +1,6 @@
 import { Directive, NgModule, forwardRef } from "@angular/core";
 import { FormsModule, NG_VALUE_ACCESSOR } from "@angular/forms";
-import { registerElement } from "nativescript-angular/elementRegistry";
+import { registerElement } from "nativescript-angular/element-registry";
 import { NativeScriptFormsModule } from "nativescript-angular/forms";
 import { TextValueAccessor } from "nativescript-angular/forms/value-accessors/text-value-accessor";
 

--- a/angular/index.ts
+++ b/angular/index.ts
@@ -1,6 +1,6 @@
 import { Directive, NgModule, forwardRef } from "@angular/core";
 import { FormsModule, NG_VALUE_ACCESSOR } from "@angular/forms";
-import { registerElement } from "nativescript-angular";
+import { registerElement } from "nativescript-angular/elementRegistry";
 import { NativeScriptFormsModule } from "nativescript-angular/forms";
 import { TextValueAccessor } from "nativescript-angular/forms/value-accessors/text-value-accessor";
 


### PR DESCRIPTION
Hi Peter,

Fixing this import makes sure that the Angular compiler doesn't end up in the webpack bundle. Ends up costing +1mb in the final bundle size, without this fix.

